### PR TITLE
Handle gene entries in the input file that don't contain the gene name

### DIFF
--- a/agfusion/parsers.py
+++ b/agfusion/parsers.py
@@ -51,11 +51,19 @@ class STARFusion(_Parser):
                 'STAR-Fusion input'
 
             for line in reader:
-                gene_5prime = line['LeftGene'].split('^')[1].split('.')[0]
-                gene_5prime_name = line['LeftGene'].split('^')[0]
+                if '^' in line['LeftGene']:
+                    gene_5prime = line['LeftGene'].split('^')[1].split('.')[0]
+                    gene_5prime_name = line['LeftGene'].split('^')[0]
+                else:
+                    gene_5prime = line['LeftGene'].split('.')[0]
+                    gene_5prime_name = gene_5prime
                 gene_5prime_junction = int(line['LeftBreakpoint'].split(':')[1])
-                gene_3prime = line['RightGene'].split('^')[1].split('.')[0]
-                gene_3prime_name = line['RightGene'].split('^')[0]
+                if '^' in line['RightGene']:
+                    gene_3prime = line['RightGene'].split('^')[1].split('.')[0]
+                    gene_3prime_name = line['RightGene'].split('^')[0]
+                else:
+                    gene_3prime = line['RightGene'].split('.')[0]
+                    gene_3prime_name = gene_3prime
                 gene_3prime_junction = int(line['RightBreakpoint'].split(':')[1])
                 self.fusions.append(
                     {


### PR DESCRIPTION
Some outputs from starfusion might look like this:
```
#FusionName             LeftGene                  RightGene
UNC5C--ENSG00000254044  UNC5C^ENSG00000182168     ENSG00000254044
```
where the LeftGene or RightGene column might only contain an ENSG ID and no gene name. This change will handle these cases.