### PR TITLE
PR to have AGFusion have a soft error when no fusions are found

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV PYENSEMBL_CACHE_DIR=/opt
 
 RUN apt-get update -y
-RUN apt-get install -y build-essential python3 python3-pip python3-matplotlib python3-pandas python3-future python3-biopython curl less vim libnss-sss git zip
+RUN apt-get install -y build-essential python3 python3-pip python3-matplotlib python3-pandas python3-future python3-biopython python3-zipfile curl less vim libnss-sss git zip
 RUN pip3 install pyensembl
 
 # Additional libraries needed for AGFusion build command

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ENV ensembl_version=105
 
 # Download latest AGFusion from source and install with pip
 WORKDIR /usr/local/bin
-RUN git clone https://github.com/ksinghal28/AGFusion.git
+RUN git clone https://github.com/genome/AGFusion.git
 WORKDIR /usr/local/bin/AGFusion
 RUN pip3 install .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ENV ensembl_version=105
 
 # Download latest AGFusion from source and install with pip
 WORKDIR /usr/local/bin
-RUN git clone https://github.com/genome/AGFusion.git
+RUN git clone https://github.com/ksinghal28/AGFusion.git
 WORKDIR /usr/local/bin/AGFusion
 RUN pip3 install .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV PYENSEMBL_CACHE_DIR=/opt
 
 RUN apt-get update -y
-RUN apt-get install -y build-essential python3 python3-pip python3-matplotlib python3-pandas python3-future python3-biopython python3-zipfile curl less vim libnss-sss git zip
+RUN apt-get install -y build-essential python3 python3-pip python3-matplotlib python3-pandas python3-future python3-biopython curl less vim libnss-sss git zip
 RUN pip3 install pyensembl
 
 # Additional libraries needed for AGFusion build command

--- a/agfusion/parsers.py
+++ b/agfusion/parsers.py
@@ -27,10 +27,10 @@ class _Parser(object):
     def _check_data(self):
         if len(self.fusions) == 0:
             #self.logger.error("Read 0 fusions from the file! Exiting...")
-            if not os.path.exists("agfusion_results"):
-                os.mkdir("agfusion_results")
-            with zipfile.ZipFile("/cromwell_root/agfusion_results.zip", mode="w") as archive:
-                archive.write("agfusion_results")
+            if not os.path.exists("/cromwell_root/agfusion_results"):
+                os.mkdir("/cromwell_root/agfusion_results")
+            #with zipfile.ZipFile("/cromwell_root/agfusion_results.zip", mode="w") as archive:
+                #archive.write("agfusion_results")
             self.logger.warning("WARNING- Read 0 fusions from the file!")
             pass
         else:

--- a/agfusion/parsers.py
+++ b/agfusion/parsers.py
@@ -5,6 +5,7 @@ Parses output files from fusion-finding algorithms
 import os
 import re
 import csv
+import zipfile
 
 
 class _Parser(object):
@@ -27,7 +28,9 @@ class _Parser(object):
         if len(self.fusions) == 0:
 #            self.logger.error("Read 0 fusions from the file! Exiting...")
             self.logger.warning("WARNING- NO FUSIONS AT ALL")
-            pass 
+            os.mkdir("agfusion_results")
+            with zipfile.ZipFile("agfusion_results.zip", mode="w") as archive:
+                archive.write("agfusion_results")
         else:
             self.logger.info(
                 "Read {} fusions from the file.".format(len(self.fusions))

--- a/agfusion/parsers.py
+++ b/agfusion/parsers.py
@@ -27,8 +27,10 @@ class _Parser(object):
     def _check_data(self):
         if len(self.fusions) == 0:
             #self.logger.error("Read 0 fusions from the file! Exiting...")
-            if not os.path.exists("/cromwell_root/agfusion_results"):
-                os.mkdir("/cromwell_root/agfusion_results")
+            if not os.path.exists("agfusion_results"):
+                os.mkdir("agfusion_results")
+            with open('agfusion_results/agfusion_readme.txt') as f:
+                f.write('No fusions detected')
             #with zipfile.ZipFile("/cromwell_root/agfusion_results.zip", mode="w") as archive:
                 #archive.write("agfusion_results")
             self.logger.warning("WARNING- Read 0 fusions from the file!")

--- a/agfusion/parsers.py
+++ b/agfusion/parsers.py
@@ -31,8 +31,6 @@ class _Parser(object):
                 os.mkdir("agfusion_results")
             with open('agfusion_results/agfusion_readme.txt', 'x') as f:
                 f.write('No fusions detected')
-            #with zipfile.ZipFile("/cromwell_root/agfusion_results.zip", mode="w") as archive:
-                #archive.write("agfusion_results")
             self.logger.warning("WARNING- Read 0 fusions from the file!")
             pass
         else:

--- a/agfusion/parsers.py
+++ b/agfusion/parsers.py
@@ -26,13 +26,12 @@ class _Parser(object):
 
     def _check_data(self):
         if len(self.fusions) == 0:
-#            self.logger.error("Read 0 fusions from the file! Exiting...")
-            self.logger.warning("WARNING- NO FUSIONS AT ALL")
-            print("making directory")
-            os.mkdir("agfusion_results")
-            print("zipping file")
-            with zipfile.ZipFile("agfusion_results.zip", mode="w") as archive:
+            #self.logger.error("Read 0 fusions from the file! Exiting...")
+            if not os.path.exists(newpath):
+                os.mkdir("agfusion_results")
+            with zipfile.ZipFile("/cromwell_root/agfusion_results.zip", mode="w") as archive:
                 archive.write("agfusion_results")
+            self.logger.warning("WARNING- Read 0 fusions from the file!")
             pass
         else:
             self.logger.info(

--- a/agfusion/parsers.py
+++ b/agfusion/parsers.py
@@ -29,8 +29,8 @@ class _Parser(object):
             #self.logger.error("Read 0 fusions from the file! Exiting...")
             if not os.path.exists("agfusion_results"):
                 os.mkdir("agfusion_results")
-            #with zipfile.ZipFile("/cromwell_root/agfusion_results.zip", mode="w") as archive:
-                #archive.write("agfusion_results")
+            with zipfile.ZipFile("/cromwell_root/agfusion_results.zip", mode="w") as archive:
+                archive.write("agfusion_results")
             self.logger.warning("WARNING- Read 0 fusions from the file!")
             pass
         else:

--- a/agfusion/parsers.py
+++ b/agfusion/parsers.py
@@ -28,9 +28,12 @@ class _Parser(object):
         if len(self.fusions) == 0:
 #            self.logger.error("Read 0 fusions from the file! Exiting...")
             self.logger.warning("WARNING- NO FUSIONS AT ALL")
+            print("making directory")
             os.mkdir("agfusion_results")
+            print("zipping file")
             with zipfile.ZipFile("agfusion_results.zip", mode="w") as archive:
                 archive.write("agfusion_results")
+            pass
         else:
             self.logger.info(
                 "Read {} fusions from the file.".format(len(self.fusions))

--- a/agfusion/parsers.py
+++ b/agfusion/parsers.py
@@ -26,6 +26,7 @@ class _Parser(object):
     def _check_data(self):
         if len(self.fusions) == 0:
 #            self.logger.error("Read 0 fusions from the file! Exiting...")
+            self.logger.warning("WARNING- NO FUSIONS AT ALL")
             pass 
         else:
             self.logger.info(

--- a/agfusion/parsers.py
+++ b/agfusion/parsers.py
@@ -27,7 +27,7 @@ class _Parser(object):
     def _check_data(self):
         if len(self.fusions) == 0:
             #self.logger.error("Read 0 fusions from the file! Exiting...")
-            if not os.path.exists(newpath):
+            if not os.path.exists("agfusion_results"):
                 os.mkdir("agfusion_results")
             with zipfile.ZipFile("/cromwell_root/agfusion_results.zip", mode="w") as archive:
                 archive.write("agfusion_results")

--- a/agfusion/parsers.py
+++ b/agfusion/parsers.py
@@ -26,7 +26,7 @@ class _Parser(object):
     def _check_data(self):
         if len(self.fusions) == 0:
 #            self.logger.error("Read 0 fusions from the file! Exiting...")
-            os.makedirs("test_empty")
+            pass 
         else:
             self.logger.info(
                 "Read {} fusions from the file.".format(len(self.fusions))

--- a/agfusion/parsers.py
+++ b/agfusion/parsers.py
@@ -2,6 +2,7 @@
 Parses output files from fusion-finding algorithms
 """
 
+import os
 import re
 import csv
 
@@ -24,7 +25,8 @@ class _Parser(object):
 
     def _check_data(self):
         if len(self.fusions) == 0:
-            self.logger.error("Read 0 fusions from the file! Exiting...")
+#            self.logger.error("Read 0 fusions from the file! Exiting...")
+            os.makedirs("test_empty")
         else:
             self.logger.info(
                 "Read {} fusions from the file.".format(len(self.fusions))

--- a/agfusion/parsers.py
+++ b/agfusion/parsers.py
@@ -5,7 +5,6 @@ Parses output files from fusion-finding algorithms
 import os
 import re
 import csv
-import zipfile
 
 
 class _Parser(object):

--- a/agfusion/parsers.py
+++ b/agfusion/parsers.py
@@ -29,8 +29,8 @@ class _Parser(object):
             #self.logger.error("Read 0 fusions from the file! Exiting...")
             if not os.path.exists("agfusion_results"):
                 os.mkdir("agfusion_results")
-            with zipfile.ZipFile("/cromwell_root/agfusion_results.zip", mode="w") as archive:
-                archive.write("agfusion_results")
+            #with zipfile.ZipFile("/cromwell_root/agfusion_results.zip", mode="w") as archive:
+                #archive.write("agfusion_results")
             self.logger.warning("WARNING- Read 0 fusions from the file!")
             pass
         else:

--- a/agfusion/parsers.py
+++ b/agfusion/parsers.py
@@ -29,7 +29,7 @@ class _Parser(object):
             #self.logger.error("Read 0 fusions from the file! Exiting...")
             if not os.path.exists("agfusion_results"):
                 os.mkdir("agfusion_results")
-            with open('agfusion_results/agfusion_readme.txt') as f:
+            with open('agfusion_results/agfusion_readme.txt', 'x') as f:
                 f.write('No fusions detected')
             #with zipfile.ZipFile("/cromwell_root/agfusion_results.zip", mode="w") as archive:
                 #archive.write("agfusion_results")


### PR DESCRIPTION
As described in issue https://github.com/griffithlab/analysis-wdls/issues/68 AGFusion currently throws an error if no fusions are detected at the RNASeq Star Fusion detect step, resulting in the pipeline completely erroring out.

This PR modifies the check_data function in parsers.py to have a warning message stating no fusions were found instead of completely erroring out. It also makes an empty agfusion_results.zip file that is needed for the later steps. 